### PR TITLE
better handling of named ranges

### DIFF
--- a/odsfile.lua
+++ b/odsfile.lua
@@ -121,7 +121,7 @@ function loadNameRanges(root, tblname)
     local a = r["_attr"] or {}
     local range = a["table:cell-range-address"] or ""
     local name = a["table:name"] 
-    if name and range:match("^"..tblname) then
+    if name and range:match("^$?"..tblname) then
       range = range:gsub("^[^%.]*",""):gsub("[%$%.]","")
       print("named range", name, range)
       t[name] = range
@@ -162,6 +162,7 @@ function tableValues(tbl,x1,y1,x2,y2)
 end
 
 function getRange(range)
+  if range == nil then return {nil,nil,nil,nil} end
   local range = namedRanges[range] or range
   local r = range:lower()
   local function getNumber(s)
@@ -174,7 +175,7 @@ function getRange(range)
     return f
   end
   for x1,y1,x2,y2 in r:gmatch("(%a*)(%d*):*(%a*)(%d*)") do
-    return getNumber(x1),tonumber(y1),getNumber(x2),tonumber(y2) 
+    return {getNumber(x1),tonumber(y1),getNumber(x2),tonumber(y2)}
    --print(string.format("%s, %s, %s, %s",getNumber(x1),y1,getNumber(x2),y2))
   end
 end

--- a/odsfile.sty
+++ b/odsfile.sty
@@ -8,10 +8,7 @@
 
 \define@key{includespread}{file}{\loadodsfile{#1}}%
 \define@key{includespread}{sheet}{\luaexec{sheetname = "\luatexluaescapestring{#1}"}}%
-\define@key{includespread}{range}{\luaexec{%
-local x1,y1,x2,y2 = odsreader.getRange("\luatexluaescapestring{#1}")%
-range = {x1,y1,x2,y2}%
-}}
+\define@key{includespread}{range}{\luaexec{range="\luatexluaescapestring{#1}"}}%
 \define@key{includespread}{template}{\luaexec{currenttemplate="\luatexluaescapestring{#1}"}}%
 \define@key{includespread}{rowtemplate}{\luaexec{rowtemplate="\luatexluaescapestring{\detokenize{#1}}"}}%
 \define@key{includespread}{celltemplate}{\luaexec{celltpl="\luatexluaescapestring{\detokenize{#1}}"}}%
@@ -107,7 +104,7 @@ multicoltpl = "\\multicolumn{-{count}}{l}{-{value}}"
 
 \newcommand\ods@includespread@unstar[1]{%
   \luaexec{%
-    range = {nil,nil,nil,nil}
+    range = nil
     rowseparator = ""
     columns=nil
     currenttemplate = nil 
@@ -119,7 +116,8 @@ multicoltpl = "\\multicolumn{-{count}}{l}{-{value}}"
   \setkeys{includespread}{#1}%
   \luaexec{%
     body   = odsreader.getTable(odsfile,sheetname)
-    local values = odsreader.tableValues(body,range[1],range[2],range[3],range[4])
+    local real_range = odsreader.getRange(range)
+    local values = odsreader.tableValues(body,real_range[1],real_range[2],real_range[3],real_range[4])
     %-- Conversion of odsfile table values to LaTeX tabular  
     local concatParagraphs = function(column)
       % -- second returned value signalize whether cell contain paragraph, or not 
@@ -187,7 +185,7 @@ multicoltpl = "\\multicolumn{-{count}}{l}{-{value}}"
       	columns = rowValues(values[1])
       	content = odsreader.table_slice(content,2,nil)
       elseif type(columns) == "number" and columns == 2 then
-      	local t = odsreader.tableValues(body,range[1],1,range[3],2)
+      	local t = odsreader.tableValues(body,real_range[1],1,real_range[3],2)
       	columns = rowValues(t[1])
       end  
       if type(columns) == "table" then colheading = table.concat(columns," & ") .. "\\OdsNl " end


### PR DESCRIPTION
tl;dr: using named range sometimes resulted in empty table and other unexpected shenanigans.

When `\includespread` is called, the first this it does is calling `\setkeys`, which then processes `range` and calls `odsreader.getRange`, which then tries to access `namedRanges` table, which is empty at this moment and won't be loaded until `odsreader.getTable` is called, which only happens later.

So I had to call `getRange` explicitly after table is already loaded.

Sidenote: because there is no check if range value is valid or not, misspelling named range still results in weird behavior instead of proper error, and I am not sure what would be a good way to deal with it.